### PR TITLE
Make workouts clickable on /dashboard page

### DIFF
--- a/src/app/dashboard/workout-calendar.tsx
+++ b/src/app/dashboard/workout-calendar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { format } from "date-fns";
 import { Calendar } from "@/components/ui/calendar";
@@ -48,16 +49,18 @@ export default function WorkoutCalendar({
             </p>
           ) : (
             workouts.map((workout) => (
-              <Card key={workout.id}>
-                <CardHeader className="pb-1">
-                  <CardTitle className="text-base">{workout.name}</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <p className="text-sm text-muted-foreground">
-                    {format(new Date(workout.createdAt), "do MMM yyyy")}
-                  </p>
-                </CardContent>
-              </Card>
+              <Link key={workout.id} href={`/dashboard/workout/${workout.id}`}>
+                <Card className="hover:bg-accent transition-colors cursor-pointer">
+                  <CardHeader className="pb-1">
+                    <CardTitle className="text-base">{workout.name}</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <p className="text-sm text-muted-foreground">
+                      {format(new Date(workout.createdAt), "do MMM yyyy")}
+                    </p>
+                  </CardContent>
+                </Card>
+              </Link>
             ))
           )}
         </div>


### PR DESCRIPTION
Wrap each workout card in a Next.js Link component to navigate to the workout detail page at /dashboard/workout/[workoutId]. Added hover styling for visual feedback.